### PR TITLE
feat: add chromium packages to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,28 @@ RUN apt-get update && \
     --no-install-recommends ca-certificates curl git unzip \
  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
+ && apt-get install -y --no-install-recommends \
+    chromium \
+    fonts-liberation \
+    fontconfig \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libgtk-3-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxss1 \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/openclaw


### PR DESCRIPTION
## Summary

Closes #2 — Add chromium and headless browser dependencies to the container build.

## Changes

Added chromium and supporting libraries to the `apt-get install` block in the Runtime Dependencies section.

## Package name corrections for Debian 13 (trixie)

Several packages in the original spec have been renamed due to the 64-bit `time_t` transition:

| Original | Trixie name |
|----------|-------------|
| `libasound2` | `libasound2t64` |
| `libatk-bridge2.0-0` | `libatk-bridge2.0-0t64` |
| `libatspi2.0-0` | `libatspi2.0-0t64` |
| `libglib2.0-0` | `libglib2.0-0t64` |
| `libgtk-3-0` | `libgtk-3-0t64` |

## Additional package

- Added `libnspr4` (NSS dependency required by chromium, not in original list but needed for correct operation)