### PR TITLE
feat: add appversion-check.sh and container-latest

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ LABEL org.opencontainers.image.documentation="https://github.com/gautada/opencla
 # └──────────────────────────────────────────────────────────┘
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    --no-install-recommends ca-certificates curl git unzip \
+    --no-install-recommends ca-certificates curl git jq unzip \
  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
@@ -66,8 +66,14 @@ USER root
 COPY openclaw-running.sh /etc/container/health.d/openclaw-running
 # RUN chmod +x /etc/container/health.d/openclaw-running
 
+COPY appversion-check.sh /etc/container/health.d/appversion-check
+RUN chmod +x /etc/container/health.d/appversion-check
+
 COPY version.sh /usr/bin/container-version
 # RUN chmod +x /usr/bin/container-version
+
+COPY latest.sh /usr/bin/container-latest
+RUN chmod +x /usr/bin/container-latest
 
 # s6 service definition
 RUN mkdir -p /etc/services.d/openclaw

--- a/appversion-check.sh
+++ b/appversion-check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Health check: verifies the running OpenClaw version matches the latest
+# release on GitHub. Calls /usr/bin/container-version for the running version
+# and /usr/bin/container-latest for the latest release.
+# Returns 0 if versions match, non-zero otherwise.
+
+# Get the version of the running OpenClaw instance
+CURRENT_VERSION=$(/usr/bin/container-version | tr -d '[:space:]')
+if [ -z "$CURRENT_VERSION" ]; then
+  echo "Failed to get running app version from /usr/bin/container-version"
+  exit 1
+fi
+
+# Get the latest release version from GitHub
+LATEST_VERSION=$(/usr/bin/container-latest)
+if [ -z "$LATEST_VERSION" ]; then
+  echo "Failed to get latest release version from /usr/bin/container-latest"
+  exit 1
+fi
+
+echo "Current version: $CURRENT_VERSION"
+echo "Latest version:  $LATEST_VERSION"
+
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+  echo "Version check passed"
+  exit 0
+else
+  echo "Version check failed: versions do not match"
+  exit 1
+fi

--- a/latest.sh
+++ b/latest.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Fetches the latest release version of openclaw from GitHub.
+# Strips the leading 'v' prefix and any whitespace, then prints
+# the clean version string to stdout.
+# Returns non-zero if the API call fails or returns no tag.
+
+LATEST=$(curl -sL "https://api.github.com/repos/openclaw/openclaw/releases/latest" \
+         | jq -r '.tag_name' \
+         | sed 's/^v//' \
+         | tr -d '[:space:]')
+
+if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+  echo "Failed to retrieve latest release version" >&2
+  exit 1
+fi
+
+printf '%s\n' "$LATEST"


### PR DESCRIPTION
## Summary

Fixes #5

Adds a new health check drop-in (`appversion-check.sh`) and a supporting utility script (`latest.sh`) to verify the running OpenClaw version matches the latest GitHub release.

---

## New Files

### `latest.sh` → `/usr/bin/container-latest`
Fetches the latest `tag_name` from `https://api.github.com/repos/openclaw/openclaw/releases/latest` via `curl` + `jq`, strips the leading `v`, removes whitespace, and prints the clean version string. Exits non-zero if the API call returns empty or `null`.

```sh
LATEST=$(curl -sL "https://api.github.com/repos/openclaw/openclaw/releases/latest" \
         | jq -r '.tag_name' \
         | sed 's/^v//' \
         | tr -d '[:space:]')
```

### `appversion-check.sh` → `/etc/container/health.d/appversion-check`
Health drop-in that compares `/usr/bin/container-version` (running app) against `/usr/bin/container-latest` (latest GitHub release). Returns 0 on match, non-zero with a descriptive message on mismatch or error. Mirrors the structure of `osversion-check.sh`.

---

## Containerfile Changes

| Change | Detail |
|--------|--------|
| `apt-get install` | Added `jq` (alphabetical: between `git` and `unzip`) |
| `COPY latest.sh` | Installs to `/usr/bin/container-latest` + `chmod +x` |
| `COPY appversion-check.sh` | Installs to `/etc/container/health.d/appversion-check` + `chmod +x` |

---

## Acceptance Criteria

- [x] `latest.sh` calls GitHub releases API via `curl -sL`
- [x] `latest.sh` extracts `tag_name` with `jq -r '.tag_name'`
- [x] `latest.sh` strips `v` prefix and whitespace
- [x] `latest.sh` exits non-zero if API returns empty or `null`
- [x] `appversion-check.sh` calls `/usr/bin/container-version` and `/usr/bin/container-latest`
- [x] `appversion-check.sh` exits 0 on match, non-zero on mismatch or empty
- [x] `jq` added to `apt-get install` in Containerfile
- [x] Both scripts COPY'd and made executable in Containerfile
- [ ] Container builds successfully (CI)
- [ ] Health check passes in a running container (end-to-end, CI)