### PR TITLE
Fix pnpm deploy for pnpm v10

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,7 +41,7 @@ RUN pnpm install --frozen-lockfile \
  && pnpm ui:build
 
 # Extract production deployment
-RUN pnpm deploy --filter=openclaw --prod /opt/openclaw-deploy
+RUN pnpm deploy --legacy --filter=openclaw --prod /opt/openclaw-deploy
 
 # ══════════════════════════════════════════════════════════════
 # Stage 2: Runtime Environment
@@ -117,16 +117,14 @@ COPY latest.sh /usr/bin/container-latest
 RUN chmod +x /etc/container/health.d/openclaw-running \
              /etc/container/health.d/appversion-check \
              /usr/bin/container-version \
-             /usr/bin/container-latest
+             /usr/bin/container-latest \
+ && mkdir -p /etc/services.d/openclaw
 
 # s6 service definition
-RUN mkdir -p /etc/services.d/openclaw
 COPY openclaw-run.sh /etc/services.d/openclaw/run
-RUN chmod +x /etc/services.d/openclaw/run
-
-# Initial configuration
 COPY openclaw.json /home/$USER/.openclaw/openclaw.json
-RUN chown -R $USER:$USER /home/$USER
+RUN chmod +x /etc/services.d/openclaw/run \
+ && chown -R $USER:$USER /home/$USER
 
 # Environment
 ENV OPENCLAW_HOME=/home/$USER


### PR DESCRIPTION
## Summary
- run `pnpm deploy` with the `--legacy` flag so pnpm v10 can deploy without injected workspace packages
- keep the runtime script block consolidated so hadolint stays green while the builder change is in place

## Acceptance Criteria
- [x] [Develop] Containerfile remains a multi-stage build
- [x] [Develop] Build stage uses `pnpm deploy --prod /opt/openclaw-deploy` (now `--legacy` to appease pnpm v10)
- [x] [Develop] Final stage copies only `/opt/openclaw-deploy`
- [x] [Develop] Entry point continues to point at the production path
- [ ] [Integrate] Image builds for arm64 & amd64 (Dev)
- [ ] [Integrate] Build log shows pnpm pruning (Dev)
- [ ] [Run] Container boots & health checks pass (Ren)
- [ ] [Run] Version + health endpoints respond (Ren)
- [ ] (Stretch) Image is ≥30% smaller than the old dev build (Ren)

## Risk
Low — Containerfile adjustments only.

## CI
Pending