### PR TITLE
fix: set ENV CI=true in builder stage to unblock pnpm

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,8 @@ RUN chmod +x /usr/bin/container-latest
 
 WORKDIR /build
 
+ENV CI=true
+
 # Clone OpenClaw at the latest release tag and build
 RUN OPENCLAW_VERSION=$(/usr/bin/container-latest) \
  && { [ -n "$OPENCLAW_VERSION" ] && [ "$OPENCLAW_VERSION" != "null" ] \


### PR DESCRIPTION
pnpm aborts removal of node_modules when no TTY is present unless CI=true is set. This caused ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY in both amd64 and arm64 build jobs.