### PR TITLE
fix: restore root USER for s6-overlay compatibility

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -117,7 +117,6 @@ RUN chmod +x \
 
 
 
-USER $USER
 
 VOLUME /mnt/volumes/data
 VOLUME /mnt/volumes/configuration

--- a/openclaw-run.sh
+++ b/openclaw-run.sh
@@ -5,35 +5,13 @@
 
 set -e
 
-# _UID=1001
+# The application user is created with UID 1001
 USER=$(getent passwd 1001 | cut -d: -f1)
 OPENCLAW_HOME="/home/${USER}"
 export OPENCLAW_HOME
 
-
- #Ensure workspace directory exists
-
-# mkdir -p "${OPENCLAW_HOME}"
-
-# Symlink configuration from mounted volume (ConfigMap)
-# ln -fsv /mnt/volumes/configuration/SOUL.md \
-#         "${OPENCLAW_HOME}/SOUL.md"
-# ln -fsv /mnt/volumes/configuration/config.yaml \
-#        "${OPENCLAW_HOME}/config.yaml"
-# 
-# # Ensure correct ownership
-# chown -R ${_UID}:${_UID} "${OPENCLAW_HOME}"
-
 # Change to application directory
-cd /opt/openclaw || echo "Unknown application directory"
+cd /opt/openclaw || exit 1
 
-# exec tail -f /dev/null
-# Start OpenClaw gateway as user nyx (uid 1001)
-# exec s6-setuidgid "${USER}" node openclaw.mjs gateway \
-#   --allow-unconfigured \
-#   --bind lan \
-#   --port 8080
-
-# exec s6-setuidgid "${USER}" pnpm openclaw gateway run
-
-exec su "${USER}" -c "pnpm openclaw gateway run"
+# Start OpenClaw gateway via s6-setuidgid
+exec s6-setuidgid "${USER}" node openclaw.mjs gateway run


### PR DESCRIPTION
Removes `USER $USER` from the Containerfile so s6-overlay's init can execute properly as root without `Permission denied` errors on `.s6-svscan`. Updates `openclaw-run.sh` to use `s6-setuidgid` to drop privileges and launch the gateway using `node openclaw.mjs gateway run` directly (bypassing pnpm since the runtime image no longer includes it).